### PR TITLE
Fix/properly configure sanctum and protect skills route

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -41,7 +41,7 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             'throttle:api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -17,7 +17,7 @@ return [
 
     'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
         '%s%s',
-        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
+        'localhost,localhost:8000,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
         Sanctum::currentApplicationUrlWithPort()
     ))),
 

--- a/resources/js/api.js
+++ b/resources/js/api.js
@@ -2,9 +2,7 @@ import axios from "axios";
 
 const api = axios.create({
     baseURL: '/api/',
-    headers: {
-        'authorization': 'Bearer ' + localStorage.getItem('access_token')
-    }
+    withCredentials: true,
 })
 
 export default api;

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,7 +19,7 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-Route::post('/skills/sync', function (Request $request) {
+Route::middleware('auth:sanctum')->post('/skills/sync', function (Request $request) {
     $skill = Skill::where('name', '=', $request->name)->first();
 
     if ($skill == null) {


### PR DESCRIPTION
Configured sanctum to properly allow API calls coming from our first-party SPA by ensuring that those requests are stateful, which basically involved registering sanctum's EnsureFrontendRequestsAreStateful middleware class, which simply allows the usage of the standard session authentication cookies to authenticate the API calls. 

Also, the 'localhost:8000' domain was missing from sanctum's stateful domains configuration which was causing issues since I was using that domain to test. 

And finally, I've configured the 'skills/sync/' route to use sanctum authentication middleware since we don't want to allow requests coming from outside our SPA. 