### PR TITLE
Feature tests for proposals

### DIFF
--- a/app/Http/Controllers/ProposalController.php
+++ b/app/Http/Controllers/ProposalController.php
@@ -20,7 +20,7 @@ class ProposalController extends Controller
         $this->authorize('viewAny', [Proposal::class, $job]);
 
         return Inertia::render('Proposals/Index', [
-            'proposals' => $job->proposals()->with(),
+            'proposals' => $job->proposals(),
             'job' => $job
         ]);
     }

--- a/app/Policies/ProposalPolicy.php
+++ b/app/Policies/ProposalPolicy.php
@@ -17,9 +17,9 @@ class ProposalPolicy
      * @param  \App\Models\User  $user
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function viewAny(User $user, Job $proposal)
+    public function viewAny(User $user, Job $job)
     {
-        $isJobOwner = $user->id  == $proposal->job->user->id;
+        $isJobOwner = $user->id == $job->user->id;
         return $isJobOwner;
     }
 

--- a/database/migrations/2023_01_23_141837_create_proposals_table.php
+++ b/database/migrations/2023_01_23_141837_create_proposals_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->id();
             $table->text('coverLetter');
             $table->double('price');
-            $table->enum('status', ['accepted', 'rejected'])->default(null);
+            $table->enum('status', ['pending', 'accepted', 'rejected'])->default('pending');
             $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
             $table->foreignId('job_id')->constrained('jobs')->cascadeOnDelete();
             $table->timestamps();

--- a/tests/Feature/ProposalTest.php
+++ b/tests/Feature/ProposalTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Job;
+use App\Models\Proposal;
+use App\Models\Skill;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class ProposalTest extends TestCase
+{
+
+    use RefreshDatabase;
+
+    /**
+     * @group ProposalFeatures
+     */
+    public function test_can_display_proposals_list_page()
+    {
+        $user = User::factory()->create();
+        $job = Job::factory()->create(['user_id' => $user->id]);
+        $response = $this->actingAs($user)->get(route('jobs.proposals.index', $job->id));
+        $response->assertOk();
+    }
+
+    /**
+     * @group ProposalFeatures
+     */
+    public function test_can_display_proposal_detail_page()
+    {
+        $user = User::factory()->create();
+        $job = Job::factory()->create(['user_id' => $user->id]);
+
+        $user = User::factory()->create();
+        $proposal = Proposal::create([
+            'coverLetter' => 'This is a new proposal',
+            'price' => 30,
+            'status' => 'accepted',
+            'user_id' => $user->id,
+            'job_id' => $job->id,
+        ]);
+
+        $response = $this->actingAs($user)->get(route('proposals.show', $proposal->id));
+        $response->assertOk();
+    }
+
+    /**
+     * @group ProposalFeatures
+     */
+    public function test_can_display_proposal_create_page()
+    {
+        // User creates a job
+        $user = User::factory()->create();
+        $job = Job::factory()->create(['user_id' => $user->id]);
+
+        // Another tries to view the form for applying to that job
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->get(route('jobs.proposals.create', $job->id));
+
+        // Check if they were able to do so
+        $response->assertOk();
+    }
+
+    /**
+     * @group ProposalFeatures
+     */
+    public function test_can_create_a_proposal()
+    {
+        // A user creates a job
+        $user = User::factory()->create();
+        $job = Job::factory()->create(['user_id' => $user->id]);
+
+        // Another user tries to submit a form for applying to that job
+        $user = User::factory()->create();
+        $proposalData = [
+            'coverLetter' => 'This is a new proposal detailed enoguh to pass the 50 character limit required for the coverLetter',
+            'price' => 50,
+        ];
+        $response = $this->actingAs($user)->post(route('jobs.proposals.store', $job->id), $proposalData);
+
+        // Check if a proposal was created successfully and there was a redirect response
+        $this->assertDatabaseCount('proposals', 1);
+        $this->assertContains($response->status(), [301, 302, 303]);
+    }
+
+    /**
+     * @group ProposalFeatures
+     */
+    public function test_can_display_proposal_edit_page()
+    {
+        // A user creates a job
+        $user = User::factory()->create();
+        $job = Job::factory()->create(['user_id' => $user->id]);
+
+        // A user tries to view their proposals edit page
+        $user = User::factory()->create();
+        $proposal = Proposal::create([
+            'coverLetter' => 'This is a new proposal',
+            'price' => 30,
+            'status' => 'accepted',
+            'user_id' => $user->id,
+            'job_id' => $job->id,
+        ]);
+        $response = $this->actingAs($user)->get(route('proposals.edit', $proposal->id));
+        $response->assertOk();
+    }
+
+    /**
+     * @group ProposalFeatures
+     */
+    public function test_can_update_a_proposal()
+    {
+        // A user creates a job
+        $user = User::factory()->create();
+        $job = Job::factory()->create(['user_id' => $user->id]);
+
+        // Another user creates a proposal on that job
+        $user = User::factory()->create();
+        $proposal = Proposal::create([
+            'coverLetter' => 'This is a new proposal',
+            'price' => 30,
+            'status' => 'accepted',
+            'user_id' => $user->id,
+            'job_id' => $job->id,
+        ]);
+
+        // And then tries to update it
+        $proposalData = [
+            'coverLetter' => 'This is a the updated proposal letter detailed enough to pass the 50 character limit on the cover letter',
+            'price' => 500
+        ];
+        $response = $this->actingAs($user)->patch(route('proposals.update', $job->id), $proposalData);
+
+        // Check if it was updated and that the user was redirected to the proposal detail page after that
+        $this->assertDatabaseHas('proposals', ['id' => $proposal->id, ...$proposalData]);
+        $response->assertRedirect(route('proposals.show', ['proposal' => $proposal->id]));
+    }
+
+    /**
+     * @group ProposalFeatures
+     */
+    public function test_can_delete_proposal()
+    {
+        // A user creates a job
+        $user = User::factory()->create();
+        $job = Job::factory()->create(['user_id' => $user->id]);
+
+        // Another user creates a proposal on that job
+        $user = User::factory()->create();
+        $proposal = Proposal::create([
+            'coverLetter' => 'This is a new proposal with',
+            'price' => 30,
+            'status' => 'accepted',
+            'user_id' => $user->id,
+            'job_id' => $job->id,
+        ]);
+
+        // And then decides to delete that proposal
+        $response = $this->actingAs($user)->delete(route('proposals.destroy', $proposal->id));
+
+        // Check if the proposal was in fact deleted
+        $this->assertDatabaseEmpty('proposals');
+    }
+}


### PR DESCRIPTION

## Changes
- Added several test cases to cover the Proposal feature, including displaying the proposals list page, displaying the proposal detail page, displaying the proposal creation page, creating a proposal and displaying the proposal edit page.
- Fixed parameter name in `viewAny` method to refer to `Job` model instead of `Proposal` model and updated the logic to reference the correct `$job` object.
- Changed the default value of the status column in the proposal migration file from null to `'pending'`, this change reflects the business logic that a proposal has a default status of pending.
- Remove the `with()` method from the proposals variable in the `index` method of the `ProposalController`.

## Test results
- All the 7 tests are passing.
- All the tests are grouped under the @group ProposalFeatures annotation.

### Note
This pull request was generated with the help of ChatGPT, an AI language model by OpenAI.