### PR TITLE
Add new test cases for ProposalController

### DIFF
--- a/tests/Feature/ProposalTest.php
+++ b/tests/Feature/ProposalTest.php
@@ -29,6 +29,21 @@ class ProposalTest extends TestCase
     /**
      * @group ProposalFeatures
      */
+    public function test_cannot_view_another_users_job_proposals_list_page()
+    {
+        // A user creates a job
+        $user = User::factory()->create();
+        $job = Job::factory()->create(['user_id' => $user->id]);
+
+        // Another one tries to view that jobs proposals page
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->get(route('jobs.proposals.index', $job->id));
+        $response->assertForbidden();
+    }
+
+    /**
+     * @group ProposalFeatures
+     */
     public function test_can_display_proposal_detail_page()
     {
         $user = User::factory()->create();
@@ -50,6 +65,41 @@ class ProposalTest extends TestCase
     /**
      * @group ProposalFeatures
      */
+    public function test_cannot_view_another_users_proposal()
+    {
+        // A user creates a job
+        $user = User::factory()->create();
+        $job = Job::factory()->create(['user_id' => $user->id]);
+
+        // Another user creates a proposal on that job
+        $user = User::factory()->create();
+        $proposal = Proposal::create([
+            'coverLetter' => 'This is a new proposal',
+            'price' => 30,
+            'status' => 'accepted',
+            'user_id' => $user->id,
+            'job_id' => $job->id,
+        ]);
+
+        // And another one tries to view that proposal
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->get(route('proposals.show', $proposal->id));
+        $response->assertForbidden();
+    }
+
+    /**
+     * @group ProposalFeatures
+     */
+    public function test_cannot_display_non_existent_proposal_detail_page()
+    {
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->get(route('proposals.show', 99999));
+        $response->assertNotFound();
+    }
+
+    /**
+     * @group ProposalFeatures
+     */
     public function test_can_display_proposal_create_page()
     {
         // User creates a job
@@ -62,6 +112,22 @@ class ProposalTest extends TestCase
 
         // Check if they were able to do so
         $response->assertOk();
+    }
+
+    /**
+     * @group ProposalFeatures
+     */
+    public function test_cannot_access_proposal_creation_form_for_own_jobs()
+    {
+        // User creates a job
+        $user = User::factory()->create();
+        $job = Job::factory()->create(['user_id' => $user->id]);
+
+        // Then tries to view the form for applying to their own job
+        $response = $this->actingAs($user)->get(route('jobs.proposals.create', $job->id));
+
+        // Check if they were able to do so
+        $response->assertForbidden();
     }
 
     /**
@@ -89,6 +155,47 @@ class ProposalTest extends TestCase
     /**
      * @group ProposalFeatures
      */
+    public function test_cannot_create_proposal_with_invalid_data()
+    {
+        // A user creates a job
+        $user = User::factory()->create();
+        $job = Job::factory()->create(['user_id' => $user->id]);
+
+        // Another user tries to submit a form for applying to that job with invalid data
+        $user = User::factory()->create();
+        $proposalData = [
+            'coverLetter' => '', // invalid data, cover letter is empty
+            'price' => 'very expensive' // price is a string,
+        ];
+        $response = $this->actingAs($user)->post(route('jobs.proposals.store', $job->id), $proposalData);
+
+        // Check if a proposal was created successfully and there was a redirect response
+        $this->assertDatabaseMissing('proposals', ['user_id' => $user->id, 'job_id' => $job->id]);
+        $response->assertSessionHasErrors(['coverLetter', 'price']);
+    }
+
+    /**
+     * @group ProposalFeatures
+     */
+    public function test_cannot_create_proposal_for_own_job()
+    {
+        // A user creates a job
+        $user = User::factory()->create();
+        $job = Job::factory()->create(['user_id' => $user->id]);
+
+        // Then the same user user tries to submit a form for applying to their own job
+        $response = $this->actingAs($user)->post(route('jobs.proposals.store', $job->id), [
+            'coverLetter' => 'This is a new proposal detailed enough to pass the 50 character limit required for the coverLetter',
+            'price' => 50,
+        ]);
+
+        // Check if not allowed
+        $response->assertForbidden();
+    }
+
+    /**
+     * @group ProposalFeatures
+     */
     public function test_can_display_proposal_edit_page()
     {
         // A user creates a job
@@ -106,6 +213,32 @@ class ProposalTest extends TestCase
         ]);
         $response = $this->actingAs($user)->get(route('proposals.edit', $proposal->id));
         $response->assertOk();
+    }
+
+    /**
+     * @group ProposalFeatures
+     */
+    public function test_cannot_edit_other_users_proposal()
+    {
+        // A user creates a job
+        $user = User::factory()->create();
+        $job = Job::factory()->create(['user_id' => $user->id]);
+
+        // A user creates a proposal
+        $proposal = Proposal::create([
+            'coverLetter' => 'This is a new proposal',
+            'price' => 30,
+            'status' => 'accepted',
+            'user_id' => $user->id,
+            'job_id' => $job->id,
+        ]);
+
+        // Another user tries to edit the proposal
+        $otherUser = User::factory()->create();
+        $response = $this->actingAs($otherUser)->get(route('proposals.edit', $proposal->id));
+
+        // Check if the user was denied access
+        $response->assertForbidden();
     }
 
     /**
@@ -142,6 +275,35 @@ class ProposalTest extends TestCase
     /**
      * @group ProposalFeatures
      */
+    public function test_cannot_update_another_users_proposal()
+    {
+        // A user creates a job
+        $user = User::factory()->create();
+        $job = Job::factory()->create(['user_id' => $user->id]);
+
+        // A user creates a proposal
+        $proposal = Proposal::create([
+            'coverLetter' => 'This is a new proposal',
+            'price' => 30,
+            'status' => 'accepted',
+            'user_id' => $user->id,
+            'job_id' => $job->id,
+        ]);
+
+        // And another then tries to update it
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->patch(route('proposals.update', $job->id), [
+            'coverLetter' => 'This is a the updated proposal letter detailed enough to pass the 50 character limit on the cover letter',
+            'price' => 500
+        ]);
+
+        // Check if the user was denied access
+        $response->assertForbidden();
+    }
+
+    /**
+     * @group ProposalFeatures
+     */
     public function test_can_delete_proposal()
     {
         // A user creates a job
@@ -163,5 +325,31 @@ class ProposalTest extends TestCase
 
         // Check if the proposal was in fact deleted
         $this->assertDatabaseEmpty('proposals');
+    }
+
+    /**
+     * @group ProposalFeatures
+     */
+    public function test_cannot_delete_another_users_proposal()
+    {
+        // A user creates a job
+        $user = User::factory()->create();
+        $job = Job::factory()->create(['user_id' => $user->id]);
+
+        // User creates a proposal on that job
+        $proposal = Proposal::create([
+            'coverLetter' => 'This is a new proposal with',
+            'price' => 30,
+            'status' => 'accepted',
+            'user_id' => $user->id,
+            'job_id' => $job->id,
+        ]);
+
+        // Another user tries to delete that proposal
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->delete(route('proposals.destroy', $proposal->id));
+
+        // Check if the proposal was in fact deleted
+        $response->assertForbidden();
     }
 }


### PR DESCRIPTION
## Summary
This pull request adds several new test cases to the ProposalFeatures test group in order to thoroughly test the Proposal feature.

### Why are these tests necessary?
Currently, the application does not have enough test coverage for the Proposal feature, especially when it comes to handling unauthorized access. These new test cases help to ensure that the application behaves correctly when unauthorized users try to access restricted functionality.

### Changes
- Added `test_cannot_view_another_users_job_proposals_list_page()` test for not allowing users to view another user's job's proposals list
- Added `test_cannot_view_another_users_proposal()` test for not allowing users to view another user's proposal page
- Added `test_cannot_display_non_existent_proposal_detail_page()` test for not allowing access to a non-existent proposal detail page
- Added `test_cannot_access_proposal_creation_form_for_own_jobs()` test for not allowing a user to access the proposal creation form for their own jobs
- Added ``
- Added `test_cannot_create_proposal_with_invalid_data()` test for not allowing the creation of proposals with invalid data
- Added `test_cannot_create_proposal_for_own_job()` test for not allowing users to apply for their own jobs
- Added `test_cannot_edit_other_users_proposal()` test for not allowing the proposal editing form of another user's proposal
- Added `test_cannot_update_another_users_proposal()` test for not allowing the proposal editing form of another user's proposal to be submitted
- Added `test_cannot_delete_another_users_proposal()` test for not allowing the deletion of another user's proposal

### NOTE
This pull request message was generated with help from chatGPT (Edited for correctness of course)
