### PR TITLE
Job features negative tests

### DIFF
--- a/app/Http/Controllers/JobController.php
+++ b/app/Http/Controllers/JobController.php
@@ -134,6 +134,8 @@ class JobController extends Controller
      */
     public function destroy(Job $job)
     {
+        $this->authorize('delete', $job);
+
         $job->delete();
         return redirect(route('jobs.index'), 303);
     }

--- a/app/Http/Controllers/JobController.php
+++ b/app/Http/Controllers/JobController.php
@@ -53,8 +53,8 @@ class JobController extends Controller
         $this->authorize('create', Job::class);
 
         $validatedJob = $request->validate([
-            'title' => 'required|string|max:255',
-            'description' => 'required|string|max:5000',
+            'title' => 'required|string|min:5|max:255',
+            'description' => 'required|string|min:5|max:5000',
             'min_price' => 'required|numeric|min:0',
             'max_price' => 'required|numeric|min:0|gt:min_price',
             'type' => 'required|in:hourly,fixed_price'

--- a/app/Http/Controllers/JobController.php
+++ b/app/Http/Controllers/JobController.php
@@ -57,7 +57,8 @@ class JobController extends Controller
             'description' => 'required|string|min:5|max:5000',
             'min_price' => 'required|numeric|min:0',
             'max_price' => 'required|numeric|min:0|gt:min_price',
-            'type' => 'required|in:hourly,fixed_price'
+            'type' => 'required|in:hourly,fixed_price',
+            'skills' => 'required|array|exists:skills,id',
         ]);
 
         $skills = $request->input('skills');
@@ -117,6 +118,7 @@ class JobController extends Controller
             'min_price' => 'numeric|min:0',
             'max_price' => 'numeric|min:0|gt:min_price',
             'type' => 'in:hourly,fixed_price',
+            'skills' => 'array|exists:skills,id',
         ]);
 
         $skills = $request->input('skills');

--- a/tests/Feature/JobTest.php
+++ b/tests/Feature/JobTest.php
@@ -44,6 +44,15 @@ class JobTest extends TestCase
     /**
      * @group JobFeatures
      */
+    public function test_cannot_display_non_existent_job_detail_page()
+    {
+        $response = $this->get(route('jobs.show', 697968));
+        $response->assertNotFound();
+    }
+
+    /**
+     * @group JobFeatures
+     */
     public function test_can_display_job_create_page()
     {
         $user = User::factory()->create();

--- a/tests/Feature/JobTest.php
+++ b/tests/Feature/JobTest.php
@@ -99,6 +99,26 @@ class JobTest extends TestCase
     /**
      * @group JobFeatures
      */
+    public function test_cannot_create_job_if_unauthorized()
+    {
+        // Try to submit job data without being unauthorized
+        $response = $this->post(route('jobs.store'), [
+            'title' => 'New Job',
+            'description' => 'New Job Description',
+            'min_price' => 20.0,
+            'max_price' => 40.0,
+            'type' => 'hourly',
+            'status' => 'open',
+            'skills' => [1, 2, 3],
+        ]);
+
+        // Check if redirected to login page
+        $response->assertRedirect(route('login'));
+    }
+
+    /**
+     * @group JobFeatures
+     */
     public function test_can_display_job_edit_page()
     {
         $user = User::factory()->create();

--- a/tests/Feature/JobTest.php
+++ b/tests/Feature/JobTest.php
@@ -99,6 +99,31 @@ class JobTest extends TestCase
     /**
      * @group JobFeatures
      */
+    public function test_cannot_create_a_job_with_invalid_fields()
+    {
+        $user = User::factory()->create();
+        Skill::insert([
+            ['name' => 'Skill 1'],
+            ['name' => 'Skill 2'],
+            ['name' => 'Skill 3'],
+        ]);
+
+        $new_job = [
+            'title' => '', // required, string, min 10 characters, max 255 characters
+            'description' => '', // required, min 50 characters, max 5000 characters
+            'min_price' => 'very low', // required, must be number, less the max_price
+            'max_price' => 'ver high', // required, must be a number, greater then min_price
+            'type' => 'in chunks', // required, must be either 'hourly' or 'fixed'
+            'skills' => [1, 2, 3],
+        ];
+        $response = $this->actingAs($user)->post(route('jobs.store'), $new_job);
+
+        $response->assertSessionHasErrors(['title', 'description', 'type', 'min_price', 'max_price', 'type'],);
+    }
+
+    /**
+     * @group JobFeatures
+     */
     public function test_cannot_create_job_if_unauthorized()
     {
         // Try to submit job data without being unauthorized

--- a/tests/Feature/JobTest.php
+++ b/tests/Feature/JobTest.php
@@ -137,6 +137,22 @@ class JobTest extends TestCase
     /**
      * @group JobFeatures
      */
+    public function test_cannot_edit_another_users_job()
+    {
+        // A user creates a job
+        $user = User::factory()->create();
+        $job = Job::factory()->create(['user_id' => $user->id]);
+
+        // Another tries to view the edit form for that job
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->get(route('jobs.edit', $job->id));
+
+        $response->assertForbidden();
+    }
+
+    /**
+     * @group JobFeatures
+     */
     public function test_can_update_job()
     {
         $user = User::factory()->create();

--- a/tests/Feature/JobTest.php
+++ b/tests/Feature/JobTest.php
@@ -182,6 +182,25 @@ class JobTest extends TestCase
     /**
      * @group JobFeatures
      */
+    public function test_cannot_update_another_users_job()
+    {
+        // A user creates a job
+        $user = User::factory()->create();
+        $job = Job::factory()->create(['user_id' => $user->id]);
+
+        // Another one tries to update that job
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->patch(route('jobs.update', $job->id), [
+            'title' => 'Updated Job Title',
+            'description' => 'Updated Job Description',
+        ]);
+
+        $response->assertForbidden();
+    }
+
+    /**
+     * @group JobFeatures
+     */
     public function test_can_delete_job()
     {
         $user = User::factory()->create();

--- a/tests/Feature/JobTest.php
+++ b/tests/Feature/JobTest.php
@@ -220,4 +220,21 @@ class JobTest extends TestCase
         $this->assertDatabaseEmpty('jobs');
         $response->assertRedirect(route('jobs.index'));
     }
+
+    /**
+     * @group JobFeatures
+     */
+    public function test_cannot_delete_another_users_job()
+    {
+        // A user creates a job
+        $user = User::factory()->create();
+        $job = Job::factory()->create(['user_id' => $user->id]);
+
+        // Another one tries to delete it
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->delete(route('jobs.destroy', $job->id));
+
+        // Check if forbiden
+        $response->assertForbidden();
+    }
 }

--- a/tests/Feature/JobTest.php
+++ b/tests/Feature/JobTest.php
@@ -124,6 +124,27 @@ class JobTest extends TestCase
     /**
      * @group JobFeatures
      */
+    public function test_cannot_create_a_job_with_non_existant_skills()
+    {
+        $user = User::factory()->create();
+
+        $new_job = [
+            'title' => 'New Job',
+            'description' => 'New Job Description',
+            'min_price' => 20.0,
+            'max_price' => 40.0,
+            'type' => 'hourly',
+            'status' => 'open',
+            'skills' => [155, 23, 53],
+        ];
+        $response = $this->actingAs($user)->post(route('jobs.store'), $new_job);
+
+        $this->assertDatabaseCount('jobs', 0);
+    }
+
+    /**
+     * @group JobFeatures
+     */
     public function test_cannot_create_job_if_unauthorized()
     {
         // Try to submit job data without being unauthorized

--- a/tests/Feature/JobTest.php
+++ b/tests/Feature/JobTest.php
@@ -63,6 +63,15 @@ class JobTest extends TestCase
     /**
      * @group JobFeatures
      */
+    public function test_cannot_access_job_creation_page_if_unauthenticated()
+    {
+        $response = $this->get(route('jobs.create'));
+        $response->assertRedirect(route('login'));
+    }
+
+    /**
+     * @group JobFeatures
+     */
     public function test_can_create_job()
     {
         $user = User::factory()->create();


### PR DESCRIPTION
## Summary
this pull request adds tests for JobController to check for negative cases where the input is invalid or
when the user is not authorized to perform a specific action to make sure that the application
responds correctly in these situations.

### Changes
- Added `test_cannot_display_non_existing_job_detail_page()` for when users tries to view a page for a job that does not exist
- Added `test_cannot_access_job_if_unauthenticated()` for when users tries to view the job creation page (by directly browsing to the URL or other ways) without being logged in
- Added `test_cannot_create_job_if_unauthorized()` the same thing as above but for when a user somehow submits that form without being authenticated (directly making a post request through code for example?)
- Added `test_cannot_edit_another_users_job()` for when a user tries to access the for editing a job of another user
- Added `test_cannot_updated_another_users_job()` same as above but for when they somehow actually submit the form sending (sending a post request) without owning that job
- Added `test_cannot_delete_another_users_job()` for when a user somehow tries to delete another users job
- Added min to title and description job validation on JobControllers create() view so users can't create jobs without a proper title and description
- Added an authorization check for checking if a user is authorized to `'delete'` the job on JobControllers `destroy()` view
- Added `test_cannot_create_a_job_with_invalid_fields()` for when a users tries to create a job with invalid fields
- Added validation checks to JobController's `store()` and `update()` views to make sure that users can only create jobs when they have selected skills that are actually available on the database
- Added `test_cannot_create_a_job_with_non_existant_fields()` to check if the application correctly handles the case when a user create a job with skill ids that do not exist in the database

### Test Results
- All 15 tests on the JobFeatures group passed
- Changes were made to relevant code to get the tests passing 

### Note
All these tests are created under the JobFeatures group and can be run by using the `php artisan test --group JobFeatures` command 