### PR TITLE
Proposal Email notifications

### DIFF
--- a/app/Http/Controllers/ProposalController.php
+++ b/app/Http/Controllers/ProposalController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Job;
 use App\Models\Proposal;
+use App\Notifications\ProposalAccepted;
 use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -150,9 +151,8 @@ class ProposalController extends Controller
         $proposal->status = $decision;
         $proposal->save();
 
-        // TODO: Send email notification to user
-
         if ($decision == 'accepted') {
+            $proposal->user->notify(new ProposalAccepted($proposal));
             // TODO: Create job contract?
         }
     }

--- a/app/Http/Controllers/ProposalController.php
+++ b/app/Http/Controllers/ProposalController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Job;
 use App\Models\Proposal;
+use App\Notifications\NewProposal;
 use App\Notifications\ProposalAccepted;
 use App\Notifications\ProposalRejected;
 use Illuminate\Auth\Middleware\Authorize;
@@ -62,6 +63,9 @@ class ProposalController extends Controller
             'job_id' => $job->id,
             'user_id' => $user->id
         ]);
+
+        // Notify the job owner
+        $job->user->notify(new NewProposal($proposal));
 
         return redirect()->route('proposals.show', [
             'proposal' => $proposal->id,

--- a/app/Http/Controllers/ProposalController.php
+++ b/app/Http/Controllers/ProposalController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Job;
 use App\Models\Proposal;
 use App\Notifications\ProposalAccepted;
+use App\Notifications\ProposalRejected;
 use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -154,6 +155,8 @@ class ProposalController extends Controller
         if ($decision == 'accepted') {
             $proposal->user->notify(new ProposalAccepted($proposal));
             // TODO: Create job contract?
+        } else if ($decision == 'rejected') {
+            $proposal->user->notify(new ProposalRejected($proposal));
         }
     }
 }

--- a/app/Notifications/NewProposal.php
+++ b/app/Notifications/NewProposal.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Proposal;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class NewProposal extends Notification
+{
+    use Queueable;
+
+    private Proposal $proposal;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct(Proposal $proposal)
+    {
+        $this->proposal = $proposal;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        $jobTitle = $this->proposal->job->title;
+        $userName = $this->proposal->user->name;
+        $url = route('proposals.show', $this->proposal->id);
+
+        return (new MailMessage)
+            ->subject("New Proposal - $jobTitle")
+            ->greeting("Hey $userName")
+            ->line("We would like to inform you that a new proposal has been submitted for your \"$jobTitle\" job. We wanted to bring this to your attention in case you would like to review and consider this candidate for the position.")
+            ->line('')
+            ->line("To view the proposal, simply click the button below:")
+            ->action('View Proposal', $url)
+            ->line('Thank you for using WorkStack to find the best candidate for your open position.');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Notifications/ProposalAccepted.php
+++ b/app/Notifications/ProposalAccepted.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Proposal;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class ProposalAccepted extends Notification
+{
+    use Queueable;
+
+    protected Proposal $proposal;
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct(Proposal $proposal)
+    {
+        $this->proposal = $proposal;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        $jobTitle = $this->proposal->job->title;
+        $userName = $this->proposal->user->name;
+        $url = route('proposals.show', $this->proposal->id);
+
+        return (new MailMessage)
+            ->subject('Your proposal has been accepted!')
+            ->greeting("Hey $userName")
+            ->line("Your proposal for '$jobTitle' on WorkStack has been accepted. Congratulations!")
+            ->line('')
+            ->line("The hiring party who reviewed your proposal will be in touch with you shortly to discuss next steps. We would like to thank you for choosing WorkStack and for your hard work in submitting your proposal.")
+            ->action('View Proposal', $url)
+            ->line('')
+            ->line('If you have any questions, please feel free to reach out to our support team.');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Notifications/ProposalRejected.php
+++ b/app/Notifications/ProposalRejected.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Proposal;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class ProposalRejected extends Notification
+{
+    use Queueable;
+
+    private Proposal $proposal;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct(Proposal $proposal)
+    {
+        $this->proposal = $proposal;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        $jobTitle = $this->proposal->job->title;
+        $userName = $this->proposal->user->name;
+        $url = route('proposals.show', $this->proposal->id);
+
+        return (new MailMessage)
+            ->subject("Proposal Rejected - $jobTitle")
+            ->greeting("Hey $userName")
+            ->line("We regret to inform you that your proposal for '$jobTitle' on WorkStack has not been accepted. Thank you for using our platform and for your interest in this opportunity!")
+            ->line('')
+            ->line("While this outcome is not what you were hoping for, we encourage you to keep using WorkStack to find other job opportunities that match your skills and experience.")
+            ->action('View Proposal', $url)
+            ->line('')
+            ->line('If you have any questions, please feel free to reach out to our support team.');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            //
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
This pull request adds three new notifications for proposal-related actions: `ProposalAccepted`, `ProposalRejected`, and `NewProposal`. These notifications are triggered in the ProposalController and provide a way for users to stay informed about proposal updates.

### Changes
- [Created `ProposalAccepted.php` notification](https://github.com/Kathenae/WorkStack/commit/05f55f20bfce1ed09e9bbde7bb14ffcf1ce02f88)
- [Send ProposalAccepted Notification on `ProposalController.php`](https://github.com/Kathenae/WorkStack/commit/bd2e7300da6378ddb6e654ad4aa51e6411829b0e)
- [Created `ProposalRejected.php` notification](https://github.com/Kathenae/WorkStack/commit/26003b239a0bb71220eb2a5447433cded1914344)
- [Send ProposalRejected notification on `ProposalController.php`](https://github.com/Kathenae/WorkStack/commit/3df424be72d0f7dc91b9039f80f8ea40971a678a)
- [Created `NewProposal.php` notification](https://github.com/Kathenae/WorkStack/commit/74a5694502b7d5fa9e9d73274e92366a73ce11f0)
- [Send NewProposal notification on `ProposalController.php`](https://github.com/Kathenae/WorkStack/commit/a1aa3985bf5d77d293943dea2e4cc3e4bb649e47)

### Issues
 - Only email notifications will be supported for now but in the future, we plan to support push notifications
 - We currently don't have a way for users to opt out of receiving these notifications
 - We might need to queue the notification so that we don't block the request for too long
 - Delay sending of notification in case the action is reversed (Eg: the user creates a proposal but immediately deletes it  afterward)